### PR TITLE
[Fix] Weaken Polylang dependency

### DIFF
--- a/lib/polylang.php
+++ b/lib/polylang.php
@@ -1,0 +1,21 @@
+<?php
+/* Copyright © 2020 École Polytechnique Fédérale de Lausanne, Switzerland */
+/* All Rights Reserved, except as stated in the LICENSE file. */
+
+/**
+ * Support code for Polylang interoperability
+ *
+ * This module defines classes (actually there is only one at the
+ * moment) that inherit from Polylang classes. Therefore, one should
+ * not attempt to load it if Polylang is not loaded.
+ */
+
+namespace EPFL\Polylang;
+
+/**
+ * Trivial subclass of @link PLL_Choose_Lang
+ *
+ * @link PLL_Choose_Lang is a class defined by the Polylang module,
+ * which is abstract for no good reason
+ */
+class PLL_Choose_Lang extends \PLL_Choose_Lang {}

--- a/lib/rest.php
+++ b/lib/rest.php
@@ -189,8 +189,8 @@ class REST_API {
      *         registered with this class.
      */
     static function _doing_rest_request () {
-        return (false !== strpos($_SERVER['REQUEST_URI'],
-                                 '/wp-json/' . _API_EPFL_PATH));
+        $epfl_wpjson_prefix = '/' . rest_get_url_prefix() . '/' . _API_EPFL_PATH;
+        return (false !== strpos($_SERVER['REQUEST_URI'], $epfl_wpjson_prefix));
     }
 
     /**
@@ -213,7 +213,8 @@ class REST_API {
         if (! (preg_match('#/$#', $base))) {
             $base = "$base/";
         }
-        return sprintf('%swp-json/%s/%s', $base,
+        return sprintf('%s%s/%s/%s', $base,
+                       rest_get_url_prefix(),
                        _API_EPFL_PATH, $relative_path);
     }
 }


### PR DESCRIPTION
(This is just https://github.com/epfl-idevelop/jahia2wp/pull/1137 rebased onto the proper place)

Make it so that `rest.php` works when the Polylang plugin is absent or
inactive.

- Move `PLL_Choose_Lang` subclassing into a new module that is
conditionally loaded only in a code path that guarantees that Polylang
is present

- Extract the \PLL_Frontend_Nav_Menu initialization from inside that
class override (untested, but this is also what `PLL_Frontend::init()`
does so we should be all good)