### PR TITLE
[feature] More menu metrics for Prometheus

### DIFF
--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1590,11 +1590,22 @@ class MenuItemController extends CustomPostTypeController
     }
 
     static function hook_rest_api_fields () {
-        register_rest_field(ExternalMenuItem::get_post_type(),
-                            'sync_status',
-                            array('get_callback' => function($post_array) {
-                                return ExternalMenuItem::get($post_array['id'])->get_sync_status();
-                            }));
+        static::register_rest_field(
+            'sync_status', function($emi) {
+                return $emi->get_sync_status();
+            });
+    }
+
+    static function register_rest_field ($attribute, $args_or_getter) {
+        if (is_callable($args_or_getter)) {
+            $args = array('get_callback' => function($post_array) use ($args_or_getter) {
+                $emi = ExternalMenuItem::get($post_array['id']);
+                return call_user_func($args_or_getter, $emi);
+            });
+        } else {
+            $args = $args_or_getter;
+        }
+        register_rest_field(ExternalMenuItem::get_post_type(), $attribute, $args);
     }
 
     static private function _get_api () {

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1594,6 +1594,18 @@ class MenuItemController extends CustomPostTypeController
             'sync_status', function($emi) {
                 return $emi->get_sync_status();
             });
+        static::register_rest_field(
+            'lang', function($emi) {
+                return $emi->get_language();
+            });
+        static::register_post_meta('site_url', array(
+            'type' => 'string',
+            'show_in_rest' => true
+        ));
+        static::register_post_meta('remote_slug', array(
+            'type' => 'string',
+            'show_in_rest' => true
+        ));
     }
 
     static function register_rest_field ($attribute, $args_or_getter) {
@@ -1606,6 +1618,14 @@ class MenuItemController extends CustomPostTypeController
             $args = $args_or_getter;
         }
         register_rest_field(ExternalMenuItem::get_post_type(), $attribute, $args);
+    }
+
+    static function register_post_meta ($attribute, $opts) {
+        if (array_key_exists($attribute, ExternalMenuItem::META_ACCESSORS)) {
+            $attribute = ExternalMenuItem::META_ACCESSORS[$attribute];
+        }
+
+        register_post_meta(ExternalMenuItem::get_post_type(), $attribute, $opts);
     }
 
     static private function _get_api () {


### PR DESCRIPTION
Additional details out of `curl -k https://wp-httpd/schools/enac/wp-json/wp/v2/epfl-external-menu` now include

- Language (`| jq '.[] | .lang'`)
- Post meta (`| jq '.[] | .meta'`), with sub-fields `epfl-emi-remote-slug` and `epfl-emi-site-url`

The (language, slug, url) triplet uniquely identifies the remote menu item, which will enable Prometheus-level aggregations on all sites that consume a given menu (see also https://github.com/epfl-si/wp-ops/pull/197).
