### PR TITLE
Fix WPCLI command name

### DIFF
--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Menus
  * Description: Stitch menus across sites
- * Version:     0.1
+ * Version:     0.2
  *
  */
 
@@ -2052,6 +2052,7 @@ class MenuFrontendController
 MenuFrontendController::hook();
 
 
-if (class_exists('\WP_CLI')) {
+if ( defined( 'WP_CLI' ) && WP_CLI ) 
+{
     require_once __DIR__ . '/wpcli.php';
 }

--- a/wpcli.php
+++ b/wpcli.php
@@ -18,7 +18,8 @@ use \EPFL\Menus\ExternalMenuItem;
 class EPFLMenusCLICommand extends WP_CLI_Command
 {
     public static function hook () {
-        WP_CLI::add_command('epfl-menus', get_called_class());
+        WP_CLI::add_command('epfl menus refresh', [get_called_class(), 'refresh' ]);
+        WP_CLI::add_command('epfl menus add-external-menu-item', [get_called_class(), 'add_external_menu_item' ]);
     }
 
     public function refresh () {
@@ -47,7 +48,7 @@ class EPFLMenusCLICommand extends WP_CLI_Command
     }
 
     /**
-     * @example wp epfl-menus add_external_menu_item --menu-location-slug=top urn:epfl:labs "laboratoires"
+     * @example wp epfl menus add-external-menu-item --menu-location-slug=top urn:epfl:labs "laboratoires"
      */
     public function add_external_menu_item ($args, $assoc_args) {
         list($urn, $title) = $args;


### PR DESCRIPTION
Sauf erreur, ce plugin a été mis dans son propre repo relativement tôt, bien avant qu'on utilise "réellement" les repos individuels pour les plugins. Ce qui fait qu'entre temps, une PR (https://github.com/epfl-si/jahia2wp/pull/1099) a été faite sur Jahia2wp pour modifier un truc au niveau des commandes WP-CLI et ça n'a pas été reporté sur le code qui se trouve dans le présent repo.

La PR courante a donc pour but de corriger ceci.