### PR TITLE
[Feature] Prune 404 subscriptions

### DIFF
--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -389,6 +389,11 @@ class PublishController
         $this->_do_forward($event);
     }
 
+    /**
+     * Forward $event to all subscribers.
+     *
+     * @param EPFL\Pubsub\Causality $event
+     */
     public function _do_forward ($event) {
         foreach (_Subscriber::all_by_publisher_url($this->subscribe_uri)
                  as $sub) {

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -408,7 +408,7 @@ class PublishController
  * Persistent records for subscribers, with contact details and
  * automated cleanup of failing subscribers
  *
- * An instance represents one subscriber, and besides it model duties
+ * An instance represents one subscriber, and besides its model duties
  * it also knows how to do some controller things, namely to send the
  * 'real' webhook (using an instance of @link Causality as the sole
  * payload), and the test one (to synchronously check that two-way

--- a/wpcli.php
+++ b/wpcli.php
@@ -15,6 +15,22 @@ use function EPFL\I18N\___;
 require_once(__DIR__ . '/epfl-menus.php');
 use \EPFL\Menus\ExternalMenuItem;
 
+function log_success ($details) {
+    if ($details) {
+        WP_CLI::log(sprintf('✓ %s', $details));
+    } else {
+        WP_CLI::log('✓');
+    }
+}
+
+function log_failure ($details) {
+    if ($details) {
+        WP_CLI::log(sprintf('\u001b[31m✗ %s\u001b[0m', $details));
+    } else {
+        WP_CLI::log(sprintf('\u001b[31m✗\u001b[0m'));
+    }
+}
+
 class EPFLMenusCLICommand extends WP_CLI_Command
 {
     public static function hook () {
@@ -39,9 +55,9 @@ class EPFLMenusCLICommand extends WP_CLI_Command
         foreach ($all as $emi) {
             try {
                 $emi->refresh();
-                WP_CLI::log(sprintf(___('✓ %s'), $emi));
+                log_success($emi);
             } catch (\Throwable $t) {
-                WP_CLI::log(sprintf(___('\u001b[31m✗ %s\u001b[0m'), $emi));
+                log_failure($emi);
             }
         }
     }

--- a/wpcli.php
+++ b/wpcli.php
@@ -15,6 +15,9 @@ use function EPFL\I18N\___;
 require_once(__DIR__ . '/epfl-menus.php');
 use \EPFL\Menus\ExternalMenuItem;
 
+require_once(__DIR__ . '/lib/pubsub.php');
+use function \EPFL\Pubsub\ping_all_subscribers;
+
 function log_success ($details) {
     if ($details) {
         WP_CLI::log(sprintf('✓ %s', $details));
@@ -34,8 +37,9 @@ function log_failure ($details) {
 class EPFLMenusCLICommand extends WP_CLI_Command
 {
     public static function hook () {
-        WP_CLI::add_command('epfl menus refresh', [get_called_class(), 'refresh' ]);
-        WP_CLI::add_command('epfl menus add-external-menu-item', [get_called_class(), 'add_external_menu_item' ]);
+        $class = get_called_class();
+        WP_CLI::add_command('epfl menus refresh', [$class, 'refresh' ]);
+        WP_CLI::add_command('epfl menus add-external-menu-item', [$class, 'add_external_menu_item' ]);
     }
 
     public function refresh () {
@@ -60,6 +64,30 @@ class EPFLMenusCLICommand extends WP_CLI_Command
                 log_failure($emi);
             }
         }
+
+        WP_CLI::log(sprintf(___('Pinging and expiring subscribers...')));
+
+        $successes = 0;
+        $notfounds = 0;
+        $errors    = 0;
+
+        ping_all_subscribers(
+            /* $success = */ function($sub) use (&$successes) {
+                log_success();
+                $successes++;
+            },
+            /* $fail = */ function($sub, $exn) use (&$notfounds, &$errors) {
+                log_failure($exn->http_code);
+                if ($exn->http_code === 404) {
+                    $notfounds++;
+                } else {
+                    $errors++;
+                }
+            }
+        );
+
+        WP_CLI::log(sprintf(___('%d subscriber(s) updated, %d 404 error(s) (dropped), %d other error(s)'),
+                            $successes, $notfounds, $errors));
     }
 
     /**

--- a/wpcli.php
+++ b/wpcli.php
@@ -44,7 +44,6 @@ class EPFLMenusCLICommand extends WP_CLI_Command
                 WP_CLI::log(sprintf(___('\u001b[31m✗ %s\u001b[0m'), $emi));
             }
         }
-        
     }
 
     /**


### PR DESCRIPTION
- Make it so that subscription pings that return a 404 in a synchronous query, expire immediately (as opposed to after a grace delay, as was the case before, and is still the case for other errors)
- `wp epfl menus refresh` now synchronously pings all known EPFL menu subscriptions in this site
