### PR TITLE
Main root menu in file

### DIFF
--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1391,6 +1391,41 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
 }
 
 /**
+ * A menu that is shared via disk (NFS).
+ */
+class OnDiskMenu {
+    static function by_entry ($entry) {
+        $thisclass = get_called_class();
+        return new $thisclass($entry->theme_location, $entry->language);
+    }
+
+    static function by_slug_and_language ($slug, $language) {
+        $thisclass = get_called_class();
+        return new $thisclass($slug, $language);
+    }
+
+    /* "private" */ function __construct ($slug, $language) {
+        $this->slug = $slug;
+        $this->language = $language;
+    }
+
+    private function _get_path () {
+        // TODO: in fact, it depends on a lot of things e.g. the NFS
+        // path, and whether there is a .ini file up in the tree (e.g.
+        // for labs)
+        return "/srv/test/wp-httpd/htdocs/epfl-full-". $this->slug ."-". $this->language ."-menu.json";
+    }
+
+    public function write ($item_list) {
+        file_put_contents($this->_get_path(), json_encode($item_list));
+    }
+
+    public function read () {
+        return json_decode(file_get_contents($this->_get_path()));
+    }
+}
+
+/**
  * Enumerate menus over the REST API
  *
  * Enumeration is independent of languages (or lack thereof) i.e.

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1639,7 +1639,7 @@ class MenuItemController extends CustomPostTypeController
                             $emi->get_site_url() == "https://www.epfl.ch") {  # meaning we are in a root but not the main, certainly a lab like site
 
                             $disk_menu = OnDiskMenu::by_entry($entry);
-                            $item_list = $menu->get_fully_stitched_tree($entry)->export_external()->as_list();
+                            $item_list = $menu->get_stitched_down_tree()->export_external()->as_list();
                             $disk_menu->write($item_list);
                         } else {
                             MenuRESTController::menu_changed($menu, $event);

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -669,7 +669,7 @@ class Menu
      */
     static function all_mapped () {
         $all = array();
-        foreach (MenuMapEntry::all() as $entry) {
+        foreach (static::iterate_mappings as $entry => $menu) {
             $menu = $entry->get_menu();
             if (! array_key_exists($menu->get_term_id(), $all)) {
                 $all[$menu->get_term_id()] = $menu;
@@ -678,9 +678,12 @@ class Menu
         return array_values($all);
     }
 
-    static function all_mapped () {
+    static function iterate_mappings () {
         foreach (MenuMapEntry::all() as $entry) {
             $menu = $entry->get_menu();
+            if (! array_key_exists($menu->get_term_id(), $all)) {
+                yield $entry => $menu;
+            }
         }
     }
 

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1347,7 +1347,7 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
         $current_external_menu_entry_url = $this->get_site_url();
         $json = "";
 
-        if ($current_external_menu_entry_url == "/") {
+        if ($current_external_menu_entry_url == "/" || $current_external_menu_entry_url == "https://www.epfl.ch") {
             $slug = $this->meta()->get_remote_slug();
             $rest_url = $this->meta()->get_rest_url();
             if (empty($rest_url)) {

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1350,9 +1350,13 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
         if ($current_external_menu_entry_url == "/") {
             $slug = $this->meta()->get_remote_slug();
             $rest_url = $this->meta()->get_rest_url();
-            $language = substr($rest_url, -2);
-            $disk_menu = OnDiskMenu::by_slug_and_language($slug, $language);
-            $json = $disk_menu->read();
+            if (empty($rest_url)) {
+                error_log(sprintf("plugin-epfl-menus: ExternalMenu '/'->rest_url must not be empty."));
+            } else {
+                $language = substr($rest_url, -2);
+                $disk_menu = OnDiskMenu::by_slug_and_language($slug, $language);
+                $json = $disk_menu->read();
+            }
         } else {
             $json = json_decode($this->meta()->get_items_json());
         }

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -527,7 +527,7 @@ class MenuItemBag
      *
      * _MUTATE_graft() does *not* tolerate ID clashes between $outer and
      * $inner; caller should ->_renumber() first as appropriate.
-     * 
+     *
      * _MUTATE_graft() may mutate (the items of) both $outer and
      * $inner (the former, because it shares them into the return
      * value). Again, caller should ->copy() as appropriate.
@@ -850,7 +850,7 @@ class Menu
             $menu_root_provider_url = Site::root()->get_path();
             if (! $menu_root_provider_url) return;
         }
-        
+
         $emi = ExternalMenuItem::find(array(
             'site_url'       => $menu_root_provider_url,
             'remote_slug'    => $theme_slug
@@ -1168,7 +1168,7 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
 
     /**
      * Get the URN of this independent menu item, or NULL if this item is not independent
-     * 
+     *
      * This shares the same data slot as @link get_rest_url.
      */
     function get_urn () {
@@ -1564,7 +1564,16 @@ class MenuItemController extends CustomPostTypeController
                 set_time_limit(0);
                 foreach (Menu::all_mapped() as $menu) {
                     if ($menu->update($emi)) {
-                        MenuRESTController::menu_changed($menu, $event);
+                        if (Site::this_site()->is_main_root()) {
+                            #TODO: set a dynamic name by # $menu->{get_theme_location}(), language
+                            $file_path = "/srv/test/wp-httpd/htdocs/epfl-full-menu.json";
+
+                            $bag = $menu->get_stitched_down_tree()->as_list();
+
+                            file_put_contents($file_path, json_encode($bag));
+                        } else {
+                            MenuRESTController::menu_changed($menu, $event);
+                        }
                     }
                 }
             });
@@ -2024,7 +2033,7 @@ class MenuFrontendController
         if (Site::this_site()->is_main_root()) {
             return true;
         }
-        
+
         $menu = Menu::by_theme_location($theme_location);
         return $menu && $menu->has_root_menu($theme_location);
     }
@@ -2052,7 +2061,7 @@ class MenuFrontendController
 MenuFrontendController::hook();
 
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) 
+if ( defined( 'WP_CLI' ) && WP_CLI )
 {
     require_once __DIR__ . '/wpcli.php';
 }

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Menus
  * Description: Stitch menus across sites
- * Version:     1.0
+ * Version:     1.1
  *
  */
 

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1615,7 +1615,7 @@ class MenuItemController extends CustomPostTypeController
                     if ($menu->update($emi)) {
                         if (Site::this_site()->is_main_root()) {
                             $disk_menu = OnDiskMenu::by_entry($entry);
-                            $item_list = $menu->get_stitched_down_tree()->as_list();
+                            $item_list = $menu->get_stitched_down_tree()->export_external()->as_list();
                             $disk_menu->write($item_list);
                         } else {
                             MenuRESTController::menu_changed($menu, $event);

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1636,7 +1636,7 @@ class MenuItemController extends CustomPostTypeController
                         }
                         elseif (!Site::this_site()->is_main_root() &&
                             Site::this_site()->is_root() &&
-                            $emi->get_site_url() == "/") {  # meaning we are in a root but not the main, certainly a lab like site
+                            $emi->get_site_url() == "https://www.epfl.ch") {  # meaning we are in a root but not the main, certainly a lab like site
 
                             $disk_menu = OnDiskMenu::by_entry($entry);
                             $item_list = $menu->get_fully_stitched_tree($entry)->export_external()->as_list();

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -678,6 +678,12 @@ class Menu
         return array_values($all);
     }
 
+    static function all_mapped () {
+        foreach (MenuMapEntry::all() as $entry) {
+            $menu = $entry->get_menu();
+        }
+    }
+
     /**
      * @return A site-wide unique integer ID for this Menu
      */
@@ -1344,8 +1350,18 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
     }
 
     function get_remote_menu () {
-        $json = $this->meta()->get_items_json();
-        if (! $json) return;
+        $current_external_menu_entry_url = $this->get_site_url();
+        $json = "";
+
+        if ($current_external_menu_entry_url == "/") {
+            $file_path = "/srv/test/wp-httpd/htdocs/epfl-full-menu.json";
+            $json = file_get_contents($file_path);
+        } else {
+            $json = $this->meta()->get_items_json();
+        }
+
+        if (empty($json)) return;
+
         return new MenuItemBag(json_decode($json));
     }
 
@@ -1566,7 +1582,11 @@ class MenuItemController extends CustomPostTypeController
                     if ($menu->update($emi)) {
                         if (Site::this_site()->is_main_root()) {
                             #TODO: set a dynamic name by # $menu->{get_theme_location}(), language
+
                             $file_path = "/srv/test/wp-httpd/htdocs/epfl-full-menu.json";
+                            $language;
+
+                            $theme_location = Menu::by_theme_location('top');
 
                             $bag = $menu->get_stitched_down_tree()->as_list();
 

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1407,7 +1407,8 @@ class OnDiskMenu {
         // TODO: in fact, it depends on a lot of things e.g. the NFS
         // path, and whether there is a .ini file up in the tree (e.g.
         // for labs)
-        return "/srv/test/wp-httpd/htdocs/epfl-full-". $this->slug ."-". $this->language ."-menu.json";
+        $htdocs_path = Site::this_site()->htdocs_path;
+        return $htdocs_path . "/epfl-full-". $this->slug ."-". $this->language ."-menu.json";
     }
 
     public function write ($item_list) {

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -375,9 +375,9 @@ class PublishController
      * Avoid loops by doing nothing if $event has already been seen
      * by any given subscriber.
      */
-    public function forward ($event) {
+    public function forward ($event, $only_urns = False) {
         _Events::action_forward($this->subscribe_uri, $event);
-        $this->_do_forward($event);
+        $this->_do_forward($event, $only_urns);
     }
 
     /**
@@ -394,9 +394,14 @@ class PublishController
      *
      * @param EPFL\Pubsub\Causality $event
      */
-    public function _do_forward ($event) {
-        foreach (_Subscriber::all_by_publisher_url($this->subscribe_uri)
-                 as $sub) {
+    public function _do_forward ($event, $only_urns = False) {
+        if ($only_urns) {
+            $subscribers = _Subscriber::urns_by_publisher_url($this->subscribe_uri);
+        } else {
+            $subscribers = _Subscriber::all_by_publisher_url($this->subscribe_uri);
+        }
+
+        foreach ($subscribers as $sub) {
             if ($sub->has_seen($event)) continue;
             $sub->attempt_post($sub->get_callback_url(), $event->marshall());
             _Events::forward_sent($this->subscribe_uri, $event);
@@ -512,11 +517,23 @@ class _Subscriber extends WPDBModel
         return static::_where("WHERE publisher_url = %s", $publisher_url);
     }
 
+    static function urns_by_publisher_url ($publisher_url) {
+        #FIXME: should not be a static value of urned subscribers,
+        # we know that urns (like labs) is subscriber_id='menu/43@https://www.epfl.ch/labs'
+        #return static::_where("WHERE publisher_url = %s AND subscriber_id LIKE '%@https://www.epfl.ch/labs'", $publisher_url);
+
+        global $wpdb;
+        $select = "SELECT id, publisher_url, subscriber_id, callback_url, UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since FROM epfl_pubsub_subscribers WHERE publisher_url = '". $publisher_url .  "' AND subscriber_id LIKE '%@http://wp-httpd/labs'";
+        $results = $wpdb->get_results($select);
+        return $results;
+    }
+
     static private function _where ($where_clause_trusted = NULL, $where_value = NULL) {
         $select = "SELECT id, publisher_url, subscriber_id, callback_url,
                  UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since
                  FROM %T";
 
+        #FIXME: $where_clause is not defined
         if ($where_clause) {
             return static::_hydrate(static::get_results("$select $where_clause_trusted",
                                                         $where_value));

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -533,8 +533,7 @@ class _Subscriber extends WPDBModel
                  UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since
                  FROM %T";
 
-        #FIXME: $where_clause is not defined
-        if ($where_clause) {
+        if ($where_clause_trusted) {
             return static::_hydrate(static::get_results("$select $where_clause_trusted",
                                                         $where_value));
         } else {

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -523,7 +523,7 @@ class _Subscriber extends WPDBModel
         #return static::_where("WHERE publisher_url = %s AND subscriber_id LIKE '%@https://www.epfl.ch/labs'", $publisher_url);
 
         global $wpdb;
-        $select = "SELECT id, publisher_url, subscriber_id, callback_url, UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since FROM epfl_pubsub_subscribers WHERE publisher_url = '". $publisher_url .  "' AND subscriber_id LIKE '%@http://wp-httpd/labs'";
+        $select = "SELECT id, publisher_url, subscriber_id, callback_url, UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since FROM epfl_pubsub_subscribers WHERE publisher_url = '". $publisher_url .  "' AND subscriber_id LIKE '%@https://www.epfl.ch/labs'";
         $results = $wpdb->get_results($select);
         return $results;
     }

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -533,7 +533,8 @@ class _Subscriber extends WPDBModel
                  UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since
                  FROM %T";
 
-        if ($where_clause_trusted) {
+        #FIXME: $where_clause is not defined
+        if ($where_clause) {
             return static::_hydrate(static::get_results("$select $where_clause_trusted",
                                                         $where_value));
         } else {


### PR DESCRIPTION
le but de cette PR est d'améliorer les performances lors de la synchronisation des menus en sauvegardant le contenu du menu complet dans 2 fichiers plats (1 fichier par langue).
Exemple: epfl-ful-top-en-menu.json

Gestion des "pods" `labs` et `associations`: 
Les fichiers plats sont sauvegardés sous `/srv/www/www.epfl.ch/htdocs` il devrait être accessible depuis les "pods" `labs` et `associations`. 
TODO: A vérifier avec @domq 

Plan de tests:

1. Ajouter une nouvelle entrée de menu dans le site canari. La nouvelle entrée de menu doit être présente partout c'est à dire dans tous les sites www, labs, associations.

2. Ajouter une nouvelle entrée de menu dans le site labs/dcsl. La nouvelle entrée de menu doit être présente partout c'est à dire dans tous les sites www, labs, associations.
