### PR TITLE
[fix] root menu propagation ("true" and "false" roots)

### DIFF
--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Menus
  * Description: Stitch menus across sites
- * Version:     1.1
+ * Version:     1.2
  *
  */
 

--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -1425,18 +1425,9 @@ class OnDiskMenu {
     }
 
     private function _get_path () {
-        // TODO: in fact, it depends on a lot of things e.g. the NFS
-        // path, and whether there is a .ini file up in the tree (e.g.
-        // for labs)
         $htdocs_path = Site::this_site()->htdocs_path;
-        return $htdocs_path . "/" . $this->get_filename();
-    }
-
-    public function get_filename () {
-        // TODO: in fact, it depends on a lot of things e.g. the NFS
-        // path, and whether there is a .ini file up in the tree (e.g.
-        // for labs)
-        return "epfl-full-". $this->slug ."-". $this->language ."-menu.json";
+        return $htdocs_path . "/epfl-full-" .
+                            $this->slug ."-". $this->language ."-menu.json";
     }
 
     public function write ($item_list) {

--- a/lib/pod.php
+++ b/lib/pod.php
@@ -93,6 +93,14 @@ class Site {
         return $path;
     }
 
+    function make_asset_path ($relpath) {
+        $homedir = $this->htdocs_path;
+        if ($this->path_under_htdocs) {
+            $homedir .= "/" . $this->path_under_htdocs;
+        }
+        return "$homedir/$relpath";
+    }
+
     function get_url () {
         return 'https://' . static::my_hostport() . $this->get_path();
     }

--- a/lib/pod.php
+++ b/lib/pod.php
@@ -45,7 +45,9 @@ class Site {
         {
             if (static::exists("$htdocs/$under_htdocs")) {
                 $thisclass = get_called_class();
-                return new $thisclass($under_htdocs);
+                $root = new $thisclass($under_htdocs);
+                $root->htdocs_path = $htdocs;
+                return $root;
             }
             if (! count($path_components)) {
                 throw new \Error('Unable to find root site from ' . WP_CONTENT_DIR);

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -375,9 +375,9 @@ class PublishController
      * Avoid loops by doing nothing if $event has already been seen
      * by any given subscriber.
      */
-    public function forward ($event, $only_urns = False) {
+    public function forward ($event) {
         _Events::action_forward($this->subscribe_uri, $event);
-        $this->_do_forward($event, $only_urns);
+        $this->_do_forward($event);
     }
 
     /**
@@ -393,16 +393,9 @@ class PublishController
      * Forward $event to subscribers.
      *
      * @param EPFL\Pubsub\Causality $event
-     * @param bool $only_urns    If True, restrict propagation to
-     *                           "URNed" subscribers, i.e. those that
-     *                           cannot reach the OnDiskMenu
      */
-    public function _do_forward ($event, $only_urns = False) {
-        if ($only_urns) {
-            $subscribers = _Subscriber::urns_by_publisher_url($this->subscribe_uri);
-        } else {
-            $subscribers = _Subscriber::all_by_publisher_url($this->subscribe_uri);
-        }
+    public function _do_forward ($event) {
+        $subscribers = _Subscriber::all_by_publisher_url($this->subscribe_uri);
 
         foreach ($subscribers as $sub) {
             if ($sub->has_seen($event)) continue;
@@ -518,12 +511,6 @@ class _Subscriber extends WPDBModel
 
     static function all_by_publisher_url ($publisher_url) {
         return static::_where("WHERE publisher_url = %s", $publisher_url);
-    }
-
-    static function urns_by_publisher_url ($publisher_url) {
-        # FIXME: should not be a static value of urned subscribers - This
-        # creates unwanted coupling between pubsub.php and epfl-menus.php
-        return static::_where("WHERE publisher_url = %s AND subscriber_id LIKE '%@https://www.epfl.ch/labs'", $publisher_url);
     }
 
     static private function _where ($where_clause_trusted = NULL, $where_value = NULL) {

--- a/lib/pubsub.php
+++ b/lib/pubsub.php
@@ -390,9 +390,12 @@ class PublishController
     }
 
     /**
-     * Forward $event to all subscribers.
+     * Forward $event to subscribers.
      *
      * @param EPFL\Pubsub\Causality $event
+     * @param bool $only_urns    If True, restrict propagation to
+     *                           "URNed" subscribers, i.e. those that
+     *                           cannot reach the OnDiskMenu
      */
     public function _do_forward ($event, $only_urns = False) {
         if ($only_urns) {
@@ -518,14 +521,9 @@ class _Subscriber extends WPDBModel
     }
 
     static function urns_by_publisher_url ($publisher_url) {
-        #FIXME: should not be a static value of urned subscribers,
-        # we know that urns (like labs) is subscriber_id='menu/43@https://www.epfl.ch/labs'
-        #return static::_where("WHERE publisher_url = %s AND subscriber_id LIKE '%@https://www.epfl.ch/labs'", $publisher_url);
-
-        global $wpdb;
-        $select = "SELECT id, publisher_url, subscriber_id, callback_url, UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since FROM epfl_pubsub_subscribers WHERE publisher_url = '". $publisher_url .  "' AND subscriber_id LIKE '%@https://www.epfl.ch/labs'";
-        $results = $wpdb->get_results($select);
-        return $results;
+        # FIXME: should not be a static value of urned subscribers - This
+        # creates unwanted coupling between pubsub.php and epfl-menus.php
+        return static::_where("WHERE publisher_url = %s AND subscriber_id LIKE '%@https://www.epfl.ch/labs'", $publisher_url);
     }
 
     static private function _where ($where_clause_trusted = NULL, $where_value = NULL) {


### PR DESCRIPTION
Before this patch, we observed two different issues:

- The JSON file containing the root menu (at www.epfl.ch) would update erratically; we would see `Call to undefined method stdClass::has_seen()` errors in the logs
- The JSON file containing the menu at www.epfl.ch/labs wouldn't update, period

During the patch, we also observed that
- The REST traffic during a menu update is blown up four-fold, because we update-and-check-a-cache-condition in a loop ☹

Changes:
- Go back to always broadcasting changes to all REST subscribers, and unfork the wonky "URNed" code paths
- In order to limit traffic at the root, the `epfl_pubsub_subscribers` table on the root site has been trimmed down a lot (according to [plan](https://docs.google.com/document/d/1hbjlOXrdz2h6iVfzqdaX298M_kOJEbApYpO7Gkyk9OM/edit))
- Refactor the logic that saves the JSON files to distinguish
    - “master” writes at the true root, whence the menu doesn't exist per se, and therefore needs recomputing by calling the stitching logic). Also, we `->write()` to a path sort of made-up by `OnDiskMenu::by_entry($entry)`;
    - vs. “slave” writes at “local” roots (e.g. `/labs`), where the path is “natural” (comes out of `$emi->get_on_disk_menu()`, extracted as part of this PR) and we simply mirror the info obtained over REST (by calling `->get_remote_menu_from_meta()`, also extracted in this PR)
