### PR TITLE
Fix notice

### DIFF
--- a/epfl-menus.php
+++ b/epfl-menus.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Menus
  * Description: Stitch menus across sites
- * Version:     1.3
+ * Version:     1.4
  *
  */
 
@@ -503,7 +503,8 @@ class MenuItemBag
     private function _MUTATE_reset_current_ancestry_status ($item) {
         unset($item->current_item_parent);
         unset($item->current_item_ancestor);
-        if ($item->classes) {
+
+        if (property_exists($item, 'classes') && $item->classes) {
             $item->classes = array_filter(
                 $item->classes,
                 function($c) {


### PR DESCRIPTION
Suppression d'une `Notice` qui rempli les logs quand on active ceux-ci pour un éventuel debug:

> PHP Notice:  Undefined property: stdClass::$classes in /wp/5.4.2/wp-content/plugins/epfl-menus/epfl-menus.php on line 506

@domq : je te laisse regarder si ma proposition de modification est correcte ou si le `property_exists` sans le 2e check après le `&&` serait suffisant.