### PR TITLE
[fix] Modify the pod name to wp-nginx

### DIFF
--- a/lib/rest.php
+++ b/lib/rest.php
@@ -482,11 +482,7 @@ class _RESTRequestSocketFireAndForget extends _RESTRequestBase {
 
 add_filter('epfl_rest_rewrite_connect_to', function($hostport, $url) {
     if ($hostport === "www.epfl.ch:443") {
-        if (preg_match('#/labs#', $url)) {
-            return "httpd-labs:8443";
-        } else {
-            return "httpd-www:8443";
-        }
+        return "wp-nginx:8443";
     } elseif ($hostport === "wp-httpd:443") {        # wp-dev
         return "wp-httpd:8443";
     } else {


### PR DESCRIPTION
Replace the old pod names with the new wp-nginx service name